### PR TITLE
Enable direct tracking from redmine

### DIFF
--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -26,12 +26,27 @@ class Assigner
   end
 
   def try_extract_id
-    id, text = self.comment.split(' ', 2)
+    return true if try_id_comment_split(comment)
+
+    _tracker, potential_hash_id_comment = comment.split(' ', 2)
+
+    if potential_hash_id_comment.start_with?('#')
+      potential_id_and_comment = potential_hash_id_comment[1..-1]
+      return true if try_id_comment_split(potential_id_and_comment)
+    end
+
+    false
+  end
+
+  def try_id_comment_split(potential_id_and_comment)
+    id, comment = potential_id_and_comment.split(' ', 2)
     success = id.to_i.to_s == id
+
     if success
       self.issue_ids << id.to_i
-      self.comment = text.to_s
+      self.comment = comment.to_s
     end
+
     return success
   end
 

--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -28,8 +28,7 @@ class Assigner
   def try_extract_id
     return true if try_id_comment_split(comment)
 
-    _tracker, potential_hash_id_comment = comment.split(' ', 2)
-
+    _tracker_name, potential_hash_id_comment = comment.split(' ', 2)
     if potential_hash_id_comment.start_with?('#')
       potential_id_and_comment = potential_hash_id_comment[1..-1]
       return true if try_id_comment_split(potential_id_and_comment)

--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -26,27 +26,24 @@ class Assigner
   end
 
   def try_extract_id
-    return true if try_id_comment_split(comment)
-
-    _tracker_name, potential_hash_id_comment = comment.split(' ', 2)
-    if potential_hash_id_comment.start_with?('#')
-      potential_id_and_comment = potential_hash_id_comment[1..-1]
-      return true if try_id_comment_split(potential_id_and_comment)
-    end
-
-    false
+    try_id_comment_split(comment) || try_hash_id_comment_split(comment)
   end
 
-  def try_id_comment_split(potential_id_and_comment)
-    id, comment = potential_id_and_comment.split(' ', 2)
-    success = id.to_i.to_s == id
+  def try_id_comment_split(comment)
+    id, comment = comment.split(' ', 2)
+    return false if id.to_i.to_s != id
 
-    if success
-      self.issue_ids << id.to_i
-      self.comment = comment.to_s
-    end
+    self.issue_ids << id.to_i
+    self.comment = comment.to_s
+  end
 
-    return success
+  def try_hash_id_comment_split(comment)
+    _tracker_name, potential_hash_id_comment = comment.split(' ', 2)
+
+    return false if potential_hash_id_comment.nil? || !potential_hash_id_comment.start_with?('#')
+
+    potential_id_and_comment = potential_hash_id_comment[1..-1]
+    try_id_comment_split(potential_id_and_comment)
   end
 
   def extract_issue_ids

--- a/spec/assigner_spec.rb
+++ b/spec/assigner_spec.rb
@@ -40,6 +40,23 @@ describe 'Assigner' do
     a.issue_ids.count.should == 1
   end
 
+  it 'should assign comment with ticket when toggled from redmine' do
+    a = Assigner.new '92345678: Feature #7682 Implement toggl directly from redmine'
+    a.issue_ids.first.should == 7682
+    a.issue_ids.count.should == 1
+  end
+
+  it 'should assign comment with ticket when toggled from redmine' do
+    a = Assigner.new '92345678: Whatever #7682 Implement toggl directly from redmine'
+    a.issue_ids.first.should == 7682
+    a.issue_ids.count.should == 1
+  end
+
+  it 'should assign comment with ticket when toggled from redmine' do
+    a = Assigner.new '92345678: Not a tracker #7682 Implement toggl directly from redmine'
+    a.issue_ids.first.should == nil
+  end
+
   it 'should not assign ticket if nil' do
     a = Assigner.new '92345678: Foo bar foo bar'
     a.issue_ids.first.should == nil
@@ -54,6 +71,16 @@ describe 'Assigner' do
   it 'should assign comment with ticket' do
     a = Assigner.new '92345678: 742 Foo bar foo bar'
     a.comment.should == 'Foo bar foo bar'
+  end
+
+  it 'should assign comment with ticket when toggled from redmine' do
+    a = Assigner.new '92345678: Feature #7682 Implement toggl directly from redmine'
+    a.comment.should == 'Implement toggl directly from redmine'
+  end
+
+  it 'should assign comment with ticket when toggled from redmine' do
+    a = Assigner.new '92345678: Whatever #7682 Implement toggl directly from redmine'
+    a.comment.should == 'Implement toggl directly from redmine'
   end
 
   it 'should assign comment with multiple tickets fake' do
@@ -83,6 +110,16 @@ describe 'Assigner' do
 
   it 'should be valid if toggle_id is present' do
     a = Assigner.new '92345678: 742 Foo bar foo bar'
+    a.valid?.should == true
+  end
+
+  it 'should assign comment with ticket when toggled from redmine' do
+    a = Assigner.new '92345678: Feature #7682 Implement toggl directly from redmine'
+    a.valid?.should == true
+  end
+
+  it 'should assign comment with ticket when toggled from redmine' do
+    a = Assigner.new '92345678: Whatever #7682 Implement toggl directly from redmine'
     a.valid?.should == true
   end
 


### PR DESCRIPTION
Enables timer start and stop directly from redmine (if you have the chrome toggl extension installed: https://chrome.google.com/webstore/detail/toggl-button-productivity/oejgccbfbmkkpaidnkphaiaecficdnfn?hl=en)

![image](https://cloud.githubusercontent.com/assets/326935/25394838/6ec01c90-29df-11e7-9be6-a976b37a4d89.png)

![image](https://cloud.githubusercontent.com/assets/326935/25394856/8062f7e2-29df-11e7-909b-8f050ce086cc.png)

![image](https://cloud.githubusercontent.com/assets/326935/25394875/8d9928b4-29df-11e7-9c94-9512929bc887.png)
